### PR TITLE
Update GeoMap component to include adaptive zoom for small polygons

### DIFF
--- a/components/entity-geo-map.vue
+++ b/components/entity-geo-map.vue
@@ -13,7 +13,7 @@ const features = computed(() => {
 <template>
 	<Card class="h-96 overflow-hidden">
 		<VisualisationContainer v-slot="{ height, width }">
-			<GeoMap v-if="height && width" :features="features" :height="height" :width="width" />
+			<GeoMap v-if="height && width" :features="features" :height="height" :width="width" adaptive-zoom />
 		</VisualisationContainer>
 	</Card>
 </template>

--- a/components/geo-map.client.vue
+++ b/components/geo-map.client.vue
@@ -3,6 +3,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 
 import { assert } from "@acdh-oeaw/lib";
 import * as turf from "@turf/turf";
+import type { FeatureCollection } from "geojson";
 import {
 	FullscreenControl,
 	type GeoJSONSource,
@@ -11,17 +12,31 @@ import {
 	NavigationControl,
 	ScaleControl,
 } from "maplibre-gl";
+import { watch } from "vue";
 
 import { type GeoMapContext, geoMapContextKey } from "@/components/geo-map.context";
 import { initialViewState } from "@/config/geo-map.config";
 import { project } from "@/config/project.config";
 import type { GeoJsonFeature } from "@/utils/create-geojson-feature";
 
-const props = defineProps<{
-	features: Array<GeoJsonFeature>;
-	height: number;
-	width: number;
-}>();
+const props = defineProps({
+	features: {
+		type: Array<GeoJsonFeature>,
+		required: true,
+	},
+	height: {
+		type: Number,
+		required: true,
+	},
+	width: {
+		type: Number,
+		required: true,
+	},
+	adaptiveZoom: {
+		type: Boolean,
+		default: false,
+	},
+});
 
 const emit = defineEmits<{
 	(
@@ -59,7 +74,7 @@ async function create() {
 	const map = new GeoMap({
 		center: [initialViewState.longitude, initialViewState.latitude],
 		container: elementRef.value,
-		maxZoom: 16,
+		maxZoom: defaultMaxZoom,
 		minZoom: 1,
 		pitch: initialViewState.pitch,
 		style: mapStyle.value,
@@ -71,6 +86,7 @@ async function create() {
 	map.on("load", init);
 }
 
+const sourceId = "data";
 function init() {
 	assert(context.map != null);
 	const map = context.map;
@@ -92,7 +108,6 @@ function init() {
 
 	//
 
-	const sourceId = "data";
 	map.addSource(sourceId, { type: "geojson", data: createFeatureCollection([]) });
 
 	//
@@ -165,24 +180,91 @@ function init() {
 function dispose() {
 	context.map?.remove();
 }
+const zoomLimit = 20;
+const maxArea = 1000;
+const minArea = 1;
+const defaultMaxZoom = 16;
+
+let geojson: FeatureCollection | null = null;
+let area = 0;
+let point: FeatureCollection | null = null;
+let zoomBreakPoint = defaultMaxZoom;
+const showPoint = ref(false);
+
+
+
+watch(showPoint, () => {
+	const source = context.map?.getSource(sourceId) as GeoJSONSource | undefined;
+	if (!source || !point || !geojson) return;
+
+	showPoint.value ? source.setData(point) : source.setData(geojson);
+})
+
+/**
+ * Gets the breakpoint for the zoom level based on the area.
+ * The smaller the area, the higher the zoom level.
+ */
+function getBreakpoint(): number {
+	if (!props.adaptiveZoom || !props.features.length || !geojson || !area) return defaultMaxZoom - 2;
+
+	if (area < minArea) return zoomLimit - 2;
+	if (area > maxArea) return zoomBreakPoint = defaultMaxZoom - 2;
+
+	return Math.round((area - minArea) / (maxArea - minArea) * (zoomLimit - defaultMaxZoom) + defaultMaxZoom) - 2;
+}
+
+function getMaxZoom() {
+	if (!props.adaptiveZoom || !props.features.length || !geojson || !area) return defaultMaxZoom;
+
+	if (area < minArea) return zoomLimit;
+	if (area > maxArea) return defaultMaxZoom;
+
+	return Math.round((area - minArea) / (maxArea - minArea) * (zoomLimit - defaultMaxZoom) + defaultMaxZoom);
+}
 
 watch(() => {
 	return props.features;
 }, update);
 
+function resetData(map: GeoMap, source?: GeoJSONSource) {
+	map.setMaxZoom(defaultMaxZoom);
+	source?.setData(createFeatureCollection([]));
+	point = null;
+	area = 0;
+}
+
 function update() {
 	assert(context.map != null);
 	const map = context.map;
 
-	const sourceId = "data";
 	const source = map.getSource(sourceId) as GeoJSONSource | undefined;
-	const geojson = createFeatureCollection(props.features);
+	geojson = createFeatureCollection(props.features);
+
+	if (!geojson.features.length) {
+		resetData(map, source);
+		return;
+	}
+
+	point = turf.centroid(geojson);
+
+	const bounds = turf.bbox(geojson);
+	area = turf.area(geojson);
+	map.setMaxZoom(getMaxZoom()); // Needs to be called after setting the area in order to work
+	zoomBreakPoint = getBreakpoint();
+
 	source?.setData(geojson);
 
-	if (geojson.features.length > 0) {
-		const bounds = turf.bbox(geojson);
-		map.fitBounds(bounds, { padding: 50 });
+	if (props.adaptiveZoom) {
+		map.on("zoom", () => {
+			if (map.getZoom() < zoomBreakPoint) {
+				showPoint.value = true;
+			} else {
+				showPoint.value = false;
+			}
+		});
 	}
+
+	map.fitBounds(bounds, { padding: 50 });
 }
 
 defineExpose(context);


### PR DESCRIPTION
Especially for the entity detail view for Archaeological sites it can happen that the polygon for the grave is so small, that it won't be visible on the normal zoom levels. 
I propose two changes to remedy this:

1. Increase the possible maximum zoom level for the detail view.
2. Swap between displaying small polygons as points or their original representation, depending on the zoom level.

The current implementation is an idea, but I am very open for changes as I think it might be beneficial, to separate between the needs of the global and entity map. 
At the moment the implementation only works for the entity view, as it reduces all geometry to a single point, this might be enough for viewing a single entity but definitely not if we've got multiple entities on the map. 