### PR TITLE
ci: skip validation for content-only changes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,8 +15,28 @@ on:
       - main
 
 jobs:
+  changes:
+    name: Check changed files
+    runs-on: ubuntu-latest
+
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - '!content/**'
+
   validate:
     name: Validate
+    needs: [changes]
+    if: ${{ needs.changes.outputs.src == 'true' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 
@@ -99,7 +119,8 @@ jobs:
           retention-days: 30
 
   build-deploy:
-    if: ${{ github.event_name == 'push' }}
+    name: Build and deploy
+    if: ${{ always() && github.event_name == 'push' }}
     needs: [validate]
     uses: ./.github/workflows/build-deploy.yml
     secrets: inherit


### PR DESCRIPTION
when only files on the `content` folder have been changes, we can skip running the validation workflow in ci.