### PR TITLE
chore: add artifact to view_classes param

### DIFF
--- a/components/data-view.vue
+++ b/components/data-view.vue
@@ -93,7 +93,7 @@ const { data, isPending, isPlaceholderData } = useGetSearchResults(
 			...params,
 			search: searchQuery,
 			show: ["description", "when"],
-			view_classes: ["actor", "event", "place", "reference", "source"],
+			view_classes: ["actor", "artifact", "event", "place", "reference", "source"],
 		};
 	}),
 );


### PR DESCRIPTION
Added "artifact" to the `view_classes` search param such that they show up in the data view (see [#2469](https://redmine.openatlas.eu/issues/2469?issue_count=7&issue_position=1&next_issue_id=2449)). We could discuss if we want to set this param to "all" instead of manually selecting classes but this could result in many unexpected classes in the search result.