### PR TITLE
style: display line-breaks in description

### DIFF
--- a/components/entity-descriptions.vue
+++ b/components/entity-descriptions.vue
@@ -23,7 +23,7 @@ const descriptions = computed(() => {
 <template>
 	<template v-if="descriptions.length > 0">
 		<template v-if="descriptions.length === 1">
-			<p class="text-md">{{ descriptions[0] }}</p>
+			<p class="whitespace-pre-line text-md">{{ descriptions[0] }}</p>
 		</template>
 		<template v-else>
 			<Tabs default-value="0">


### PR DESCRIPTION
Adds `white-space: pre-line` to display line breaks coded as `\n` in the description (see [#2470](https://redmine.openatlas.eu/issues/2470)).