### PR TITLE
hotfix: handle missing entity geometry

### DIFF
--- a/components/data-map-view.vue
+++ b/components/data-map-view.vue
@@ -110,9 +110,14 @@ const mode = computed(() => {
  * because `maplibre-gl` will serialize geojson features when sending them to the webworker.
  */
 const features = computed(() => {
-	return entities.value.map((entity) => {
-		return createGeoJsonFeature(entity);
-	});
+	return entities.value
+		.filter((entity) => {
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `geometry` is not always present since OA Version 8.10.0
+			return entity.geometry;
+		})
+		.map((entity) => {
+			return createGeoJsonFeature(entity);
+		});
 });
 
 const centerpoints = computed(() => {

--- a/components/mode-switch.vue
+++ b/components/mode-switch.vue
@@ -54,11 +54,11 @@ function entityHasCoordinates(entity: EntityFeature) {
 		hasPlace.value = false;
 	}
 	if (project.map.mapDisplayedSystemClasses.includes(entity.systemClass)) {
-		if (entity.geometry.type === "GeometryCollection" && entity.geometry.geometries.length === 0) {
+		if (entity.geometry?.type === "GeometryCollection" && entity.geometry.geometries.length === 0) {
 			hasPlace.value = false;
 		} else if (
-			entity.geometry.type !== "GeometryCollection" &&
-			entity.geometry.coordinates.length === 0
+			entity.geometry?.type !== "GeometryCollection" &&
+			entity.geometry?.coordinates.length === 0
 		) {
 			hasPlace.value = false;
 		} else hasPlace.value = true;
@@ -81,7 +81,7 @@ function entityInNetwork(entity: EntityFeature) {
 						:class="
 							props.currentMode === 'map'
 								? 'rounded-md bg-brand p-4 shadow-md'
-								: 'rounded-md bg-primary/90 p-4 shadow-md dark:bg-white' && !hasPlace
+								: !hasPlace
 									? 'rounded-md bg-neutral-300 p-4 shadow-md'
 									: 'rounded-md bg-primary/90 p-4 shadow-md dark:bg-white'
 						"
@@ -115,7 +115,7 @@ function entityInNetwork(entity: EntityFeature) {
 						:class="
 							props.currentMode === 'network'
 								? 'rounded-md bg-brand p-4 shadow-md'
-								: 'rounded-md bg-primary/90 p-4 shadow-md dark:bg-white' && !inNetwork
+								: !inNetwork
 									? 'rounded-md bg-neutral-300 p-4 shadow-md'
 									: 'rounded-md bg-primary/90 p-4 shadow-md dark:bg-white'
 						"

--- a/composables/use-filter-relations.ts
+++ b/composables/use-filter-relations.ts
@@ -1,7 +1,7 @@
 type Relations = Array<NonNullable<EntityFeature["relations"]>[0]>;
 
 export const useFilterRelations = (
-	relations: MaybeRef<Relations> | undefined,
+	relations: MaybeRef<Relations> | null | undefined,
 	filters: MaybeRef<{
 		relationType?: RelationType;
 		systemClass?: EntityFeature["systemClass"];

--- a/lib/api-client/api.ts
+++ b/lib/api-client/api.ts
@@ -67,7 +67,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/display/{entityId}": {
+    "/display/{fileId}": {
         parameters: {
             query?: never;
             header?: never;
@@ -118,6 +118,51 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/entity_presentation_view/{entityId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Retrieves an Entity with its linked data for presentation sites */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /**
+                     * @description Specific entity ID
+                     * @example 40
+                     */
+                    entityId: components["parameters"]["entityId"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Successful response */
+                200: {
+                    headers: Record<string, unknown>;
+                    content: {
+                        "application/json": components["schemas"]["PresentationViewModel"];
+                    };
+                };
+                /** @description Something went wrong. Please consult the error message. */
+                404: {
+                    headers: Record<string, unknown>;
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/export_database/{format}": {
         parameters: {
             query?: never;
@@ -152,7 +197,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/iiif_manifest/{version}/{entityId}": {
+    "/iiif_manifest/{version}/{fileId}": {
         parameters: {
             query?: never;
             header?: never;
@@ -447,58 +492,69 @@ export interface components {
         };
         ClassMappingModel: {
             locale?: string;
-            results?: {
+            results?: Array<{
                 crmClass: string;
                 icon: string;
                 label: string;
                 systemClass: string;
                 view: string;
-            }[];
+            }>;
         };
-        ClassesModel: {
+        ClassesModel: Array<{
             crmClass: string;
             en: string;
             icon: string;
             systemClass: string;
             view: string;
-        }[];
+        }>;
         EntitiesOutputModel: {
             pagination: components["schemas"]["PaginationModel"];
-            results: (components["schemas"]["LinkedPlacesModel"] | components["schemas"]["GeoJSONModel"])[];
+            results: Array<components["schemas"]["GeoJSONModel"] | components["schemas"]["LinkedPlacesModel"]>;
         };
+        EntityTypeModel: {
+            descriptions?: string | null;
+            id: number;
+            isStandard: boolean;
+            title: string;
+            typeHierarchy?: Array<components["schemas"]["TypeHierarchyEntryModel"]> | null;
+        } | null;
+        ExternalReferenceModel: {
+            id: string;
+            identifier: string;
+            referenceSystem: string;
+            referenceURL: string;
+            resolverURL: string;
+            type: string;
+        } | null;
         GeoJSONModel: {
-            features: {
-                geometry: components["schemas"]["Polygon"] | components["schemas"]["Point"] | components["schemas"]["LineString"] | components["schemas"]["GeometryCollection"];
+            features: Array<{
+                geometry: components["schemas"]["GeometryCollection"] | components["schemas"]["LineString"] | components["schemas"]["Point"] | components["schemas"]["Polygon"];
                 properties: {
                     "@id": number;
-                    /** Format: nullable */
-                    begin_comment: string;
+                    begin_comment: string | null;
                     begin_earliest: string;
-                    /** Format: nullable */
-                    begin_latest: string;
+                    begin_latest: string | null;
                     description: string;
-                    /** Format: nullable */
-                    end_comment: string;
+                    end_comment: string | null;
                     end_earliest: string;
-                    /** Format: nullable */
-                    end_latest: string;
+                    end_latest: string | null;
                     name: string;
                     systemClass: string;
-                    types: {
+                    types: Array<{
                         typeId?: number;
                         typeName?: string;
-                    }[];
+                    }>;
                     viewClass: string;
                 };
                 type?: string;
-            }[];
+            }>;
             /** @enum {string} */
             type: "FeatureCollection";
         };
         GeometricEntitiesModel: {
-            features?: {
+            features?: Array<{
                 geometry?: {
-                    coordinates?: number[];
+                    coordinates?: Array<number>;
                     type?: string;
                 };
                 properties?: {
@@ -516,11 +572,11 @@ export interface components {
                     shapeType?: string;
                 };
                 type?: string;
-            }[];
+            }>;
             type?: string;
         };
         GeometryCollection: {
-            geometries: (components["schemas"]["Polygon"] | components["schemas"]["Point"] | components["schemas"]["LineString"])[];
+            geometries: Array<components["schemas"]["LineString"] | components["schemas"]["Point"] | components["schemas"]["Polygon"]>;
             /** @enum {string} */
             type: "GeometryCollection";
         };
@@ -548,23 +604,23 @@ export interface components {
         LineStringCoordinates: [
             components["schemas"]["Position"],
             components["schemas"]["Position"],
-            ...components["schemas"]["Position"][]
+            ...Array<components["schemas"]["Position"]>
         ];
         LinearRing: [
             components["schemas"]["Position"],
             components["schemas"]["Position"],
             components["schemas"]["Position"],
             components["schemas"]["Position"],
-            ...components["schemas"]["Position"][]
+            ...Array<components["schemas"]["Position"]>
         ];
         LinkedPlacesModel: {
             "@context": string;
-            features: {
+            features: Array<{
                 "@id": string;
                 crmClass: string;
-                /** Format: nullable */
-                depictions?: {
+                depictions?: Array<{
                     "@id"?: string;
+                    IIIFBasePath?: string;
                     IIIFManifest?: string;
                     creator?: string;
                     license?: string;
@@ -573,97 +629,79 @@ export interface components {
                     publicShareable?: boolean;
                     title?: string;
                     url?: string;
-                }[];
-                descriptions: {
+                }> | null;
+                descriptions?: Array<{
                     value?: string;
-                }[];
-                geometry: components["schemas"]["Polygon"] | components["schemas"]["Point"] | components["schemas"]["LineString"] | components["schemas"]["GeometryCollection"];
-                /** Format: nullable */
-                links?: string;
-                /** Format: nullable */
-                names?: string;
-                properties: {
+                }>;
+                geometry?: (components["schemas"]["GeometryCollection"] | components["schemas"]["LineString"] | components["schemas"]["Point"] | components["schemas"]["Polygon"]) | null;
+                links?: string | null;
+                names?: string | null;
+                properties?: {
                     title: string;
                 };
-                relations?: {
+                relations?: Array<{
                     label?: string;
-                    /** Format: nullable */
-                    relationDescription?: string;
+                    relationDescription?: string | null;
                     relationSystemClass?: string;
                     relationTo?: string;
                     relationType?: string;
-                    /** Format: nullable */
-                    type?: string;
+                    type?: string | null;
                     when?: {
-                        timespans?: {
+                        timespans?: Array<{
                             end?: {
-                                /** Format: nullable */
-                                comment?: string;
-                                /** Format: nullable */
-                                earliest?: string;
-                                /** Format: nullable */
-                                latest?: string;
+                                comment?: string | null;
+                                earliest?: string | null;
+                                latest?: string | null;
                             };
                             start?: {
-                                /** Format: nullable */
-                                comment?: string;
-                                /** Format: nullable */
-                                earliest?: string;
-                                /** Format: nullable */
-                                latest?: string;
+                                comment?: string | null;
+                                earliest?: string | null;
+                                latest?: string | null;
                             };
-                        }[];
-                    };
-                }[];
+                        }>;
+                    } | null;
+                }> | null;
                 systemClass: string;
                 type: string;
-                types?: {
-                    /** Format: nullable */
-                    descriptions?: string;
+                types?: Array<{
+                    descriptions?: string | null;
                     hierarchy?: string;
                     identifier?: string;
                     label?: string;
-                    typeHierarchy?: {
+                    typeHierarchy?: Array<{
                         description?: string;
                         identifier?: string;
                         label?: string;
-                    }[];
-                    /** Format: nullable */
-                    unit?: string;
+                    }>;
+                    unit?: string | null;
                     /** Format: float */
                     value?: number;
-                }[];
+                }> | null;
                 viewClass: string;
                 when?: {
-                    timespans?: {
+                    timespans?: Array<{
                         end?: {
-                            /** Format: nullable */
-                            comment?: string;
-                            /** Format: nullable */
-                            earliest?: string;
-                            /** Format: nullable */
-                            latest?: string;
+                            comment?: string | null;
+                            earliest?: string | null;
+                            latest?: string | null;
                         };
                         start?: {
-                            /** Format: nullable */
-                            comment?: string;
-                            /** Format: nullable */
-                            earliest?: string;
-                            /** Format: nullable */
-                            latest?: string;
+                            comment?: string | null;
+                            earliest?: string | null;
+                            latest?: string | null;
                         };
-                    }[];
-                };
-            }[];
+                    }>;
+                } | null;
+            }>;
             type: string;
         };
         NetworkVisualisationModel: {
-            results: {
+            results: Array<{
                 id: number;
                 label: string;
-                relations: number[];
+                relations: Array<number>;
                 systemClass: string;
-            }[];
+            }>;
         };
         PaginationIndexModel: {
             page?: number;
@@ -672,7 +710,7 @@ export interface components {
         PaginationModel: {
             entities: number;
             entitiesPerPage: number;
-            index: components["schemas"]["PaginationIndexModel"][];
+            index: Array<components["schemas"]["PaginationIndexModel"]>;
             totalPages: number;
         };
         Point: {
@@ -685,7 +723,7 @@ export interface components {
             type: "Point";
         };
         Polygon: {
-            coordinates: components["schemas"]["LinearRing"][];
+            coordinates: Array<components["schemas"]["LinearRing"]>;
             description?: string;
             /** @enum {string} */
             shapeType?: "area" | "shape";
@@ -694,9 +732,62 @@ export interface components {
             type: "Polygon";
         };
         Position: [
-        ] | [
             number
+        ] | [
         ];
+        PresentationViewModel: {
+            aliases: Array<string>;
+            description: string;
+            externalReferenceSystems?: Array<components["schemas"]["ExternalReferenceModel"]> | null;
+            files?: Array<{
+                creator?: string | null;
+                id: number;
+                license: string | null;
+                licenseHolder?: string | null;
+                mimetype: string;
+                publicShareable?: boolean | null;
+                title: string;
+                url: string;
+            }> | null;
+            geometries?: {
+                coordinates: Array<number>;
+                description: string;
+                shapeType: string;
+                title: string;
+                type: string;
+            } | null;
+            id: number;
+            relations?: {
+                acquisition?: Array<components["schemas"]["RelatedEntityModel"]>;
+                activity?: Array<components["schemas"]["RelatedEntityModel"]>;
+                actor_function?: Array<components["schemas"]["RelatedEntityModel"]>;
+                actor_relation?: Array<components["schemas"]["RelatedEntityModel"]>;
+                appellation?: Array<components["schemas"]["RelatedEntityModel"]>;
+                artifact?: Array<components["schemas"]["RelatedEntityModel"]>;
+                bibliography?: Array<components["schemas"]["RelatedEntityModel"]>;
+                creation?: Array<components["schemas"]["RelatedEntityModel"]>;
+                edition?: Array<components["schemas"]["RelatedEntityModel"]>;
+                event?: Array<components["schemas"]["RelatedEntityModel"]>;
+                external_reference?: Array<components["schemas"]["RelatedEntityModel"]>;
+                feature?: Array<components["schemas"]["RelatedEntityModel"]>;
+                file?: Array<components["schemas"]["RelatedEntityModel"]>;
+                group?: Array<components["schemas"]["RelatedEntityModel"]>;
+                human_remains?: Array<components["schemas"]["RelatedEntityModel"]>;
+                involvement?: Array<components["schemas"]["RelatedEntityModel"]>;
+                modification?: Array<components["schemas"]["RelatedEntityModel"]>;
+                move?: Array<components["schemas"]["RelatedEntityModel"]>;
+                person?: Array<components["schemas"]["RelatedEntityModel"]>;
+                place?: Array<components["schemas"]["RelatedEntityModel"]>;
+                production?: Array<components["schemas"]["RelatedEntityModel"]>;
+                source?: Array<components["schemas"]["RelatedEntityModel"]>;
+                source_translation?: Array<components["schemas"]["RelatedEntityModel"]>;
+                stratigraphic_unit?: Array<components["schemas"]["RelatedEntityModel"]>;
+            };
+            systemClass: string;
+            title: string;
+            types?: Array<components["schemas"]["EntityTypeModel"]> | null;
+            when?: components["schemas"]["TimeRangeModel"];
+        };
         PropertiesDetailModel: {
             code: string;
             count: number;
@@ -710,8 +801,8 @@ export interface components {
             name: string;
             nameInverse: string;
             rangeClassCode: string;
-            sub?: string[];
-            super: string[];
+            sub?: Array<string>;
+            super: Array<string>;
         };
         PropertiesModel: {
             OA7: components["schemas"]["PropertiesDetailModel"];
@@ -865,12 +956,33 @@ export interface components {
             P98: components["schemas"]["PropertiesDetailModel"];
             P99: components["schemas"]["PropertiesDetailModel"];
         };
-        SubunitsModel: {
-            children: number[];
+        RelatedEntityModel: {
+            aliases?: Array<string>;
+            description: string;
+            geometries: Record<string, never>;
+            id: number;
+            relationTypesModel?: Array<components["schemas"]["RelationTypeModel"]>;
+            standardType?: {
+                id?: number;
+                title?: string;
+            };
+            systemClass: string;
+            title: string;
+            when: components["schemas"]["TimeRangeModel"];
+        } | null;
+        RelationTypeModel: {
+            description?: string | null;
+            property: string;
+            relationTo: number;
+            type?: string | null;
+            when?: components["schemas"]["TimeRangeModel"];
+        } | null;
+        SubunitsModel: Array<{
+            children: Array<number>;
             created: string;
             crmClass: string;
             geometry: {
-                coordinates?: number[];
+                coordinates?: Array<number>;
                 description?: string;
                 shapeType?: string;
                 title?: string;
@@ -884,37 +996,34 @@ export interface components {
             /** Format: int32 */
             parentId: number;
             properties: {
-                /** Format: nullable */
-                aliases: string;
+                aliases: string | null;
                 description: string;
-                externalReferences: {
+                externalReferences: Array<{
                     id: string;
                     identifier: string;
                     referenceSystem: string;
                     referenceURL: string;
                     resolverURL: string;
                     type: string;
-                }[];
-                /** Format: nullable */
-                files: string;
+                }>;
+                files: string | null;
                 name: string;
-                references: {
+                references: Array<{
                     abbreviation: string;
                     /** Format: int32 */
                     id: number;
-                    /** Format: nullable */
-                    pages: string;
+                    pages: string | null;
                     title: string;
-                }[];
+                }>;
                 standardType: {
-                    externalReferences: {
+                    externalReferences: Array<{
                         id: string;
                         identifier: string;
                         referenceSystem: string;
                         referenceURL: string;
                         resolverURL: string;
                         type: string;
-                    }[];
+                    }>;
                     /** Format: int32 */
                     id: number;
                     name: string;
@@ -928,30 +1037,28 @@ export interface components {
                     latestBegin: string;
                     latestEnd: string;
                 };
-                types: {
-                    externalReferences: {
+                types: Array<{
+                    externalReferences: Array<{
                         id?: string;
                         identifier?: string;
                         referenceSystem?: string;
                         referenceURL?: string;
                         resolverURL?: string;
                         type?: string;
-                    }[];
+                    }>;
                     /** Format: int32 */
                     id: number;
                     name: string;
                     path: string;
                     /** Format: int32 */
                     rootId: number;
-                    /** Format: nullable */
-                    unit: string;
-                    /** Format: nullable */
-                    value: string;
-                }[];
+                    unit: string | null;
+                    value: string | null;
+                }>;
             };
             /** Format: int32 */
             rootId: number;
-        }[];
+        }>;
         SystemClassCountModel: {
             /** Format: int32 */
             acquisition: number;
@@ -988,19 +1095,36 @@ export interface components {
             /** Format: int32 */
             type: number;
         };
+        TimeRangeModel: {
+            end: {
+                comment: string | null;
+                earliest: string | null;
+                latest: string | null;
+            };
+            start: {
+                comment: string | null;
+                earliest: string | null;
+                latest: string | null;
+            };
+        };
+        TypeHierarchyEntryModel: {
+            descriptions?: string | null;
+            identifier: string;
+            label: string;
+        };
         TypeOverviewEntryModel: {
-            children: components["schemas"]["TypeOverviewEntryModel"][];
+            children: Array<components["schemas"]["TypeOverviewEntryModel"]>;
             /** Format: int32 */
             id: number;
             name: string;
-            viewClass: string[];
+            viewClass: Array<string>;
         };
         TypeOverviewModel: {
-            custom: components["schemas"]["TypeOverviewEntryModel"][];
-            place: components["schemas"]["TypeOverviewEntryModel"][];
-            standard: components["schemas"]["TypeOverviewEntryModel"][];
-            system: components["schemas"]["TypeOverviewEntryModel"][];
-            value: components["schemas"]["TypeOverviewEntryModel"][];
+            custom: Array<components["schemas"]["TypeOverviewEntryModel"]>;
+            place: Array<components["schemas"]["TypeOverviewEntryModel"]>;
+            standard: Array<components["schemas"]["TypeOverviewEntryModel"]>;
+            system: Array<components["schemas"]["TypeOverviewEntryModel"]>;
+            value: Array<components["schemas"]["TypeOverviewEntryModel"]>;
         };
         TypeTreeModel: {
             type_tree: {
@@ -1014,57 +1138,57 @@ export interface components {
                     last: number;
                     name: string;
                     origin_id: number;
-                    root: number[];
-                    subs: number[];
+                    root: Array<number>;
+                    subs: Array<number>;
                 };
             };
         };
         TypeViewClassChildren: {
-            children: components["schemas"]["TypeViewClassChildren"][];
+            children: Array<components["schemas"]["TypeViewClassChildren"]>;
             id: string;
             label: string;
             url: string;
         };
         TypesByViewClassEntry: {
             category: string;
-            children: components["schemas"]["TypeViewClassChildren"][];
+            children: Array<components["schemas"]["TypeViewClassChildren"]>;
             id: number;
             name: string;
         };
         TypesByViewClassModel: {
-            acquisition: components["schemas"]["TypesByViewClassEntry"][];
-            activity: components["schemas"]["TypesByViewClassEntry"][];
-            actor_actor_relation: components["schemas"]["TypesByViewClassEntry"][];
-            actor_function: components["schemas"]["TypesByViewClassEntry"][];
-            artifact: components["schemas"]["TypesByViewClassEntry"][];
-            bibliography: components["schemas"]["TypesByViewClassEntry"][];
-            creation: components["schemas"]["TypesByViewClassEntry"][];
-            edition: components["schemas"]["TypesByViewClassEntry"][];
-            event: components["schemas"]["TypesByViewClassEntry"][];
-            external_reference: components["schemas"]["TypesByViewClassEntry"][];
-            feature: components["schemas"]["TypesByViewClassEntry"][];
-            file: components["schemas"]["TypesByViewClassEntry"][];
-            group: components["schemas"]["TypesByViewClassEntry"][];
-            human_remains: components["schemas"]["TypesByViewClassEntry"][];
-            involvement: components["schemas"]["TypesByViewClassEntry"][];
-            move: components["schemas"]["TypesByViewClassEntry"][];
-            person: components["schemas"]["TypesByViewClassEntry"][];
-            place: components["schemas"]["TypesByViewClassEntry"][];
-            production: components["schemas"]["TypesByViewClassEntry"][];
-            source: components["schemas"]["TypesByViewClassEntry"][];
-            source_translation: components["schemas"]["TypesByViewClassEntry"][];
-            stratigraphic_unit: components["schemas"]["TypesByViewClassEntry"][];
+            acquisition: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            activity: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            actor_actor_relation: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            actor_function: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            artifact: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            bibliography: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            creation: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            edition: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            event: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            external_reference: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            feature: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            file: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            group: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            human_remains: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            involvement: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            move: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            person: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            place: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            production: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            source: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            source_translation: Array<components["schemas"]["TypesByViewClassEntry"]>;
+            stratigraphic_unit: Array<components["schemas"]["TypesByViewClassEntry"]>;
         };
-        searchCriteria: {
+        searchCriteria: Array<{
             /**
              * @default and
              * @enum {string}
              */
-            logicalOperator: "or" | "and";
+            logicalOperator: "and" | "or";
             /** @enum {string} */
-            operator?: "equal" | "notEqual" | "like" | "greaterThan" | "greaterThanEqual" | "lesserThan" | "lesserThanEqual";
-            values?: (string | number)[];
-        }[];
+            operator?: "equal" | "greaterThan" | "greaterThanEqual" | "lesserThan" | "lesserThanEqual" | "like" | "notEqual";
+            values?: Array<number | string>;
+        }>;
     };
     responses: never;
     parameters: {
@@ -1079,57 +1203,62 @@ export interface components {
          * @description CIDOC classes to be requested
          * @example E18
          */
-        cidoc_classes: ("all" | "E6" | "E7" | "E8" | "E9" | "E12" | "E18" | "E20" | "E21" | "E22" | "E31" | "E32" | "E33" | "E41" | "E53" | "E54" | "E55" | "E74")[];
+        cidoc_classes: Array<"all" | "E6" | "E7" | "E8" | "E9" | "E12" | "E18" | "E20" | "E21" | "E22" | "E31" | "E32" | "E33" | "E41" | "E53" | "E54" | "E55" | "E74">;
         /**
          * @description Choose one column to sort the results by. Default value is name.
          * @example name
          */
-        column: "id" | "name" | "cidoc_class" | "system_class" | "begin_from" | "begin_to" | "end_from" | "end_to";
+        column: "begin_from" | "begin_to" | "cidoc_class" | "end_from" | "end_to" | "id" | "name" | "system_class";
         /** @description Show integer count of how many entities would the result give back */
         count: boolean;
         /** @description Download results */
         download: boolean;
         /** @description Entity ids which will be requested */
-        entities: number[];
+        entities: Array<number>;
         /**
          * @description Specific entity ID
          * @example 40
          */
         entityId: number;
         /** @description System classes to be excluded from network */
-        exclude_system_classes: ("acquisition" | "activity" | "administrative_unit" | "appellation" | "artifact" | "bibliography" | "creation" | "edition" | "event" | "external_reference" | "feature" | "file" | "group" | "human_remains" | "move" | "person" | "place" | "production" | "reference_system" | "source" | "source_translation" | "stratigraphic_unit" | "type" | "type_tools")[];
+        exclude_system_classes: Array<"acquisition" | "activity" | "administrative_unit" | "appellation" | "artifact" | "bibliography" | "creation" | "edition" | "event" | "external_reference" | "feature" | "file" | "group" | "human_remains" | "move" | "person" | "place" | "production" | "reference_system" | "source_translation" | "source" | "stratigraphic_unit" | "type_tools" | "type">;
         /** @description Export the entities into either a simple CSV representation or a zip file of CSV's especially designed for network analyses. */
         export: "csv" | "csvNetwork";
+        /**
+         * @description Specific ID of a file entity.
+         * @example 40
+         */
+        fileId: number;
         /** @description Begin results at the given entity id. */
         first: number;
         /**
          * @description Choose the format for the results.
          * @example lp
          */
-        format: "lp" | "lpx" | "geojson" | "geojson-v2" | "pretty-xml" | "n3" | "turtle" | "nt" | "xml";
+        format: "geojson-v2" | "geojson" | "lp" | "lpx" | "n3" | "nt" | "pretty-xml" | "turtle" | "xml";
         /** @description Filters which geometries will be received. Default is gisAll */
-        geometry: ("gisAll" | "gisPointAll" | "gisPointSupers" | "gisPointSubs" | "gisPointSibling" | "gisLineAll" | "gisPolygonAll")[];
+        geometry: Array<"gisAll" | "gisLineAll" | "gisPointAll" | "gisPointSibling" | "gisPointSubs" | "gisPointSupers" | "gisPolygonAll">;
         /**
          * @description Select which size of the image you want to display. Values are fixed but can be changed for each OpenAtlas instance. Thumbnail is 200px and table 100px.
          * @example table
          */
-        image_size: "thumbnail" | "table";
+        image_size: "table" | "thumbnail";
         /** @description Begin results after the given entity id. */
         last: number;
         /** @description Limits the entities displayed. Influences the performance of the request. Default value is 20. 0 means all available entities will be displayed. */
         limit: number;
         /** @description Entity IDs, from which all linked entities are requested */
-        linked_entities: number[];
+        linked_entities: Array<number>;
         /** @description Show only entities, which are linked to given IDs */
-        linked_to_ids: number[];
+        linked_to_ids: Array<number>;
         /** @description Choose language for system inherent labels */
         locale: "ca" | "de" | "en" | "es" | "fr";
         /** @description Jump to page number. */
         page: number;
         /** @description Retrieves entities which are connected to the requested entity with the `property` */
-        properties: ("all" | "P43" | "P140" | "P99" | "P112" | "P113" | "P17" | "P104" | "P142" | "P195" | "P164" | "P129" | "P33" | "P53" | "P42" | "P48" | "P37" | "P182" | "P132" | "P56" | "P148" | "P150" | "P100" | "P180" | "P98" | "P74" | "P124" | "P152" | "OA8" | "P20" | "P25" | "P144" | "P2" | "P54" | "P97" | "P34" | "P175" | "P51" | "P123" | "P55" | "P70" | "P8" | "P11" | "P196" | "P126" | "P105" | "P44" | "P109" | "P12" | "P9" | "P156" | "P86" | "P111" | "P4" | "P197" | "P179" | "P128" | "P141" | "P19" | "P65" | "P103" | "P59" | "P183" | "P15" | "P89" | "P184" | "P94" | "P92" | "P110" | "P16" | "P130" | "P72" | "P1" | "P68" | "P188" | "P23" | "P125" | "P93" | "P160" | "P50" | "P95" | "P40" | "P62" | "P198" | "P49" | "P145" | "P139" | "P174" | "P31" | "P28" | "P177" | "P21" | "P26" | "P5" | "P135" | "P22" | "P14" | "P136" | "P189" | "P137" | "P106" | "P166" | "P69" | "P27" | "P101" | "P38" | "P35" | "P10" | "P143" | "P173" | "P75" | "P176" | "P127" | "P108" | "P76" | "P91" | "P24" | "P73" | "P133" | "P29" | "OA9" | "P191" | "P96" | "P71" | "P165" | "P7" | "P67" | "P161" | "P186" | "P107" | "P134" | "P146" | "P13" | "P121" | "P46" | "P185" | "P39" | "P45" | "P32" | "P187" | "P147" | "P157" | "P122" | "P30" | "OA7" | "P52" | "P151" | "P167" | "P102" | "P41" | "P138")[];
+        properties: Array<"all" | "OA7" | "OA8" | "OA9" | "P1" | "P2" | "P4" | "P5" | "P7" | "P8" | "P9" | "P10" | "P11" | "P12" | "P13" | "P14" | "P15" | "P16" | "P17" | "P19" | "P20" | "P21" | "P22" | "P23" | "P24" | "P25" | "P26" | "P27" | "P28" | "P29" | "P30" | "P31" | "P32" | "P33" | "P34" | "P35" | "P37" | "P38" | "P39" | "P40" | "P41" | "P42" | "P43" | "P44" | "P45" | "P46" | "P48" | "P49" | "P50" | "P51" | "P52" | "P53" | "P54" | "P55" | "P56" | "P59" | "P62" | "P65" | "P67" | "P68" | "P69" | "P70" | "P71" | "P72" | "P73" | "P74" | "P75" | "P76" | "P86" | "P89" | "P91" | "P92" | "P93" | "P94" | "P95" | "P96" | "P97" | "P98" | "P99" | "P100" | "P101" | "P102" | "P103" | "P104" | "P105" | "P106" | "P107" | "P108" | "P109" | "P110" | "P111" | "P112" | "P113" | "P121" | "P122" | "P123" | "P124" | "P125" | "P126" | "P127" | "P128" | "P129" | "P130" | "P132" | "P133" | "P134" | "P135" | "P136" | "P137" | "P138" | "P139" | "P140" | "P141" | "P142" | "P143" | "P144" | "P145" | "P146" | "P147" | "P148" | "P150" | "P151" | "P152" | "P156" | "P157" | "P160" | "P161" | "P164" | "P165" | "P166" | "P167" | "P173" | "P174" | "P175" | "P176" | "P177" | "P179" | "P180" | "P182" | "P183" | "P184" | "P185" | "P186" | "P187" | "P188" | "P189" | "P191" | "P195" | "P196" | "P197" | "P198">;
         /** @description Displays only connections connected by the selected CIDOC CRM property code. If geometry, types, depictions and/or links is in the show parameter, these properties are also displayed. */
-        relation_type: ("P43" | "P140" | "P99" | "P112" | "P113" | "P17" | "P104" | "P142" | "P195" | "P164" | "P129" | "P33" | "P53" | "P42" | "P48" | "P37" | "P182" | "P132" | "P56" | "P148" | "P150" | "P100" | "P180" | "P98" | "P74" | "P124" | "P152" | "OA8" | "P20" | "P25" | "P144" | "P2" | "P54" | "P97" | "P34" | "P175" | "P51" | "P123" | "P55" | "P70" | "P8" | "P11" | "P196" | "P126" | "P105" | "P44" | "P109" | "P12" | "P9" | "P156" | "P86" | "P111" | "P4" | "P197" | "P179" | "P128" | "P141" | "P19" | "P65" | "P103" | "P59" | "P183" | "P15" | "P89" | "P184" | "P94" | "P92" | "P110" | "P16" | "P130" | "P72" | "P1" | "P68" | "P188" | "P23" | "P125" | "P93" | "P160" | "P50" | "P95" | "P40" | "P62" | "P198" | "P49" | "P145" | "P139" | "P174" | "P31" | "P28" | "P177" | "P21" | "P26" | "P5" | "P135" | "P22" | "P14" | "P136" | "P189" | "P137" | "P106" | "P166" | "P69" | "P27" | "P101" | "P38" | "P35" | "P10" | "P143" | "P173" | "P75" | "P176" | "P127" | "P108" | "P76" | "P91" | "P24" | "P73" | "P133" | "P29" | "OA9" | "P191" | "P96" | "P71" | "P165" | "P7" | "P67" | "P161" | "P186" | "P107" | "P134" | "P146" | "P13" | "P121" | "P46" | "P185" | "P39" | "P45" | "P32" | "P187" | "P147" | "P157" | "P122" | "P30" | "OA7" | "P52" | "P151" | "P167" | "P102" | "P41" | "P138")[];
+        relation_type: Array<"OA7" | "OA8" | "OA9" | "P1" | "P2" | "P4" | "P5" | "P7" | "P8" | "P9" | "P10" | "P11" | "P12" | "P13" | "P14" | "P15" | "P16" | "P17" | "P19" | "P20" | "P21" | "P22" | "P23" | "P24" | "P25" | "P26" | "P27" | "P28" | "P29" | "P30" | "P31" | "P32" | "P33" | "P34" | "P35" | "P37" | "P38" | "P39" | "P40" | "P41" | "P42" | "P43" | "P44" | "P45" | "P46" | "P48" | "P49" | "P50" | "P51" | "P52" | "P53" | "P54" | "P55" | "P56" | "P59" | "P62" | "P65" | "P67" | "P68" | "P69" | "P70" | "P71" | "P72" | "P73" | "P74" | "P75" | "P76" | "P86" | "P89" | "P91" | "P92" | "P93" | "P94" | "P95" | "P96" | "P97" | "P98" | "P99" | "P100" | "P101" | "P102" | "P103" | "P104" | "P105" | "P106" | "P107" | "P108" | "P109" | "P110" | "P111" | "P112" | "P113" | "P121" | "P122" | "P123" | "P124" | "P125" | "P126" | "P127" | "P128" | "P129" | "P130" | "P132" | "P133" | "P134" | "P135" | "P136" | "P137" | "P138" | "P139" | "P140" | "P141" | "P142" | "P143" | "P144" | "P145" | "P146" | "P147" | "P148" | "P150" | "P151" | "P152" | "P156" | "P157" | "P160" | "P161" | "P164" | "P165" | "P166" | "P167" | "P173" | "P174" | "P175" | "P176" | "P177" | "P179" | "P180" | "P182" | "P183" | "P184" | "P185" | "P186" | "P187" | "P188" | "P189" | "P191" | "P195" | "P196" | "P197" | "P198">;
         /** @description Search query for specific results.
          *
          *      **Filterable categories**
@@ -1138,7 +1267,9 @@ export interface components {
          *
          *      **Values**
          *
-         *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.\n *Notes*:
+         *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.
+         *
+         *      *Notes*:
          *      The category valueTypeID can search for values of a type ID. But it takes one or more two valued Tuple as list entry: (x,y). x is the type id and y is the searched value. This can be an int or a float, e.g: `{"operator":"lesserThan","values":[(3142,543.3)],"logicalOperator":"and"}`
          *      The date categories (beginFrom, beginTo, endFrom, endTo) only allow *one* value in the **values** field and it has to be formated the following way: YYYY-MM-DD. Month and day values need to filled up with 0, e.g. 800-01-01
          *
@@ -1154,10 +1285,32 @@ export interface components {
          *
          *     **Logical operators**
          *
-         *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND. */
+         *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND.
+         *
+         *      The following table outlines the supported operations for each field:
+         *
+         *     |                  | equal     | notEqual  | like      | greaterThan | greaterThanEqual | lesserThan | lesserThanEqual |
+         *     |------------------|-----------|-----------|-----------|-------------|------------------|------------|-----------------|
+         *     | entityName       |     x      |     x      |    x       |             |                  |            |                 |
+         *     | entityDescription|      x     |      x     |      x     |             |                  |            |                 |
+         *     | entityAliases    |      x     |      x     |     x      |             |                  |            |                 |
+         *     | entityCidocClass |      x     |      x     |      x     |             |                  |            |                 |
+         *     | entitySystemClass|      x     |      x     |     x      |             |                  |            |                 |
+         *     | typeName         |       x    |      x     |     x      |             |                  |            |                 |
+         *     | entityID         |       x    |      x     |           |             |                  |            |                 |
+         *     | typeID           |      x     |       x    |           |             |                  |            |                 |
+         *     | valueTypeID      |      x     |      x     |           |      x       |    x              |    x        |      x           |
+         *     | typeIDWithSubs   |      x     |       x    |           |             |                  |            |                 |
+         *     | relationToID     |      x     |      x     |           |             |                  |            |                 |
+         *     | beginFrom        |      x     |      x     |           |      x       |        x          |     x       |      x           |
+         *     | beginTo          |      x     |      x     |           |      x       |          x        |      x      |       x          |
+         *     | endFrom          |      x     |      x     |           |       x      |         x         |       x     |       x          |
+         *     | endTo            |      x     |      x     |           |       x      |       x           |       x     |      x           |
+         *
+         *      */
         search: string;
         /** @description Select which keys should not be displayed. This can improve performance */
-        show: ("when" | "types" | "relations" | "names" | "links" | "geometry" | "depictions" | "geonames" | "description" | "none")[];
+        show: Array<"depictions" | "description" | "geometry" | "geonames" | "links" | "names" | "none" | "relations" | "types" | "when">;
         /**
          * @description Sorting result ascending or descending of the given column. Default value is asc.
          * @example asc
@@ -1167,23 +1320,23 @@ export interface components {
          * @description System class to be requested
          * @example acquisition
          */
-        system_class: "all" | "acquisition" | "activity" | "administrative_unit" | "appellation" | "artifact" | "bibliography" | "creation" | "edition" | "event" | "external_reference" | "feature" | "file" | "group" | "human_remains" | "move" | "object_location" | "person" | "place" | "production" | "reference_system" | "source" | "source_translation" | "stratigraphic_unit" | "type" | "tools";
+        system_class: "acquisition" | "activity" | "administrative_unit" | "all" | "appellation" | "artifact" | "bibliography" | "creation" | "edition" | "event" | "external_reference" | "feature" | "file" | "group" | "human_remains" | "move" | "object_location" | "person" | "place" | "production" | "reference_system" | "source_translation" | "source" | "stratigraphic_unit" | "tools" | "type";
         /** @description System classes to be requested */
-        system_classes: ("all" | "acquisition" | "activity" | "administrative_unit" | "appellation" | "artifact" | "bibliography" | "creation" | "edition" | "event" | "external_reference" | "feature" | "file" | "group" | "human_remains" | "move" | "object_location" | "person" | "place" | "production" | "reference_system" | "source" | "source_translation" | "stratigraphic_unit" | "type" | "tools")[];
+        system_classes: Array<"acquisition" | "activity" | "administrative_unit" | "all" | "appellation" | "artifact" | "bibliography" | "creation" | "edition" | "event" | "external_reference" | "feature" | "file" | "group" | "human_remains" | "move" | "object_location" | "person" | "place" | "production" | "reference_system" | "source_translation" | "source" | "stratigraphic_unit" | "tools" | "type">;
         /** @description Show only entities with the given type id or linked to it. */
-        type_id: number[];
+        type_id: Array<number>;
         /** @description Provide a valid URL, e.g. https://openatlas.eu/. At an IIIF endpoint this will replace the base URL of all annotations. */
         url: string;
         /**
          * @description View class to be requested
          * @example actor
          */
-        view_class: "all" | "actor" | "artifact" | "event" | "file" | "place" | "reference" | "reference_system" | "source" | "source_translation" | "type";
+        view_class: "actor" | "all" | "artifact" | "event" | "file" | "place" | "reference_system" | "reference" | "source_translation" | "source" | "type";
         /**
          * @description View classes to be requested
          * @example actor
          */
-        view_classes: ("all" | "actor" | "artifact" | "event" | "file" | "place" | "reference" | "reference_system" | "source" | "source_translation" | "type")[];
+        view_classes: Array<"actor" | "all" | "artifact" | "event" | "file" | "place" | "reference_system" | "reference" | "source_translation" | "source" | "type">;
     };
     requestBodies: never;
     headers: never;
@@ -1205,18 +1358,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": components["schemas"]["BackendDetailsModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1255,7 +1404,9 @@ export interface operations {
                  *
                  *      **Values**
                  *
-                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.\n *Notes*:
+                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.
+                 *
+                 *      *Notes*:
                  *      The category valueTypeID can search for values of a type ID. But it takes one or more two valued Tuple as list entry: (x,y). x is the type id and y is the searched value. This can be an int or a float, e.g: `{"operator":"lesserThan","values":[(3142,543.3)],"logicalOperator":"and"}`
                  *      The date categories (beginFrom, beginTo, endFrom, endTo) only allow *one* value in the **values** field and it has to be formated the following way: YYYY-MM-DD. Month and day values need to filled up with 0, e.g. 800-01-01
                  *
@@ -1271,7 +1422,29 @@ export interface operations {
                  *
                  *     **Logical operators**
                  *
-                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND. */
+                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND.
+                 *
+                 *      The following table outlines the supported operations for each field:
+                 *
+                 *     |                  | equal     | notEqual  | like      | greaterThan | greaterThanEqual | lesserThan | lesserThanEqual |
+                 *     |------------------|-----------|-----------|-----------|-------------|------------------|------------|-----------------|
+                 *     | entityName       |     x      |     x      |    x       |             |                  |            |                 |
+                 *     | entityDescription|      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entityAliases    |      x     |      x     |     x      |             |                  |            |                 |
+                 *     | entityCidocClass |      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entitySystemClass|      x     |      x     |     x      |             |                  |            |                 |
+                 *     | typeName         |       x    |      x     |     x      |             |                  |            |                 |
+                 *     | entityID         |       x    |      x     |           |             |                  |            |                 |
+                 *     | typeID           |      x     |       x    |           |             |                  |            |                 |
+                 *     | valueTypeID      |      x     |      x     |           |      x       |    x              |    x        |      x           |
+                 *     | typeIDWithSubs   |      x     |       x    |           |             |                  |            |                 |
+                 *     | relationToID     |      x     |      x     |           |             |                  |            |                 |
+                 *     | beginFrom        |      x     |      x     |           |      x       |        x          |     x       |      x           |
+                 *     | beginTo          |      x     |      x     |           |      x       |          x        |      x      |       x          |
+                 *     | endFrom          |      x     |      x     |           |       x      |         x         |       x     |       x          |
+                 *     | endTo            |      x     |      x     |           |       x      |       x           |       x     |      x           |
+                 *
+                 *      */
                 search?: components["parameters"]["search"];
                 /** @description Begin results at the given entity id. */
                 first?: components["parameters"]["first"];
@@ -1304,18 +1477,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/ld+json": components["schemas"]["EntitiesOutputModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1336,18 +1505,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": components["schemas"]["ClassMappingModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1363,18 +1528,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": components["schemas"]["ClassesModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1382,15 +1543,15 @@ export interface operations {
     DisplayImage: {
         parameters: {
             query?: {
-                image_size?: "thumbnail" | "table";
+                image_size?: "table" | "thumbnail";
             };
             header?: never;
             path: {
                 /**
-                 * @description Specific entity ID
+                 * @description Specific ID of a file entity.
                  * @example 40
                  */
-                entityId: components["parameters"]["entityId"];
+                fileId: components["parameters"]["fileId"];
             };
             cookie?: never;
         };
@@ -1398,9 +1559,7 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "image/jpeg": string;
                     "image/png": string;
@@ -1408,9 +1567,7 @@ export interface operations {
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1449,7 +1606,9 @@ export interface operations {
                  *
                  *      **Values**
                  *
-                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.\n *Notes*:
+                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.
+                 *
+                 *      *Notes*:
                  *      The category valueTypeID can search for values of a type ID. But it takes one or more two valued Tuple as list entry: (x,y). x is the type id and y is the searched value. This can be an int or a float, e.g: `{"operator":"lesserThan","values":[(3142,543.3)],"logicalOperator":"and"}`
                  *      The date categories (beginFrom, beginTo, endFrom, endTo) only allow *one* value in the **values** field and it has to be formated the following way: YYYY-MM-DD. Month and day values need to filled up with 0, e.g. 800-01-01
                  *
@@ -1465,7 +1624,29 @@ export interface operations {
                  *
                  *     **Logical operators**
                  *
-                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND. */
+                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND.
+                 *
+                 *      The following table outlines the supported operations for each field:
+                 *
+                 *     |                  | equal     | notEqual  | like      | greaterThan | greaterThanEqual | lesserThan | lesserThanEqual |
+                 *     |------------------|-----------|-----------|-----------|-------------|------------------|------------|-----------------|
+                 *     | entityName       |     x      |     x      |    x       |             |                  |            |                 |
+                 *     | entityDescription|      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entityAliases    |      x     |      x     |     x      |             |                  |            |                 |
+                 *     | entityCidocClass |      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entitySystemClass|      x     |      x     |     x      |             |                  |            |                 |
+                 *     | typeName         |       x    |      x     |     x      |             |                  |            |                 |
+                 *     | entityID         |       x    |      x     |           |             |                  |            |                 |
+                 *     | typeID           |      x     |       x    |           |             |                  |            |                 |
+                 *     | valueTypeID      |      x     |      x     |           |      x       |    x              |    x        |      x           |
+                 *     | typeIDWithSubs   |      x     |       x    |           |             |                  |            |                 |
+                 *     | relationToID     |      x     |      x     |           |             |                  |            |                 |
+                 *     | beginFrom        |      x     |      x     |           |      x       |        x          |     x       |      x           |
+                 *     | beginTo          |      x     |      x     |           |      x       |          x        |      x      |       x          |
+                 *     | endFrom          |      x     |      x     |           |       x      |         x         |       x     |       x          |
+                 *     | endTo            |      x     |      x     |           |       x      |       x           |       x     |      x           |
+                 *
+                 *      */
                 search?: components["parameters"]["search"];
                 /** @description Begin results at the given entity id. */
                 first?: components["parameters"]["first"];
@@ -1498,18 +1679,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/ld+json": components["schemas"]["EntitiesOutputModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1547,18 +1724,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
-                    "application/ld+json": components["schemas"]["LinkedPlacesModel"] | components["schemas"]["GeoJSONModel"];
+                    "application/ld+json": components["schemas"]["GeoJSONModel"] | components["schemas"]["LinkedPlacesModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1569,7 +1742,7 @@ export interface operations {
             header?: never;
             path: {
                 /** @example json */
-                format: "json" | "csv" | "xml";
+                format: "csv" | "json" | "xml";
             };
             cookie?: never;
         };
@@ -1577,18 +1750,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": string;
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1611,18 +1780,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": components["schemas"]["GeometricEntitiesModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1637,10 +1802,10 @@ export interface operations {
             path: {
                 version: 2;
                 /**
-                 * @description Specific entity ID
+                 * @description Specific ID of a file entity.
                  * @example 40
                  */
-                entityId: components["parameters"]["entityId"];
+                fileId: components["parameters"]["fileId"];
             };
             cookie?: never;
         };
@@ -1648,9 +1813,7 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "image/jpeg": string;
                     "image/png": string;
@@ -1658,9 +1821,7 @@ export interface operations {
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1697,7 +1858,9 @@ export interface operations {
                  *
                  *      **Values**
                  *
-                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.\n *Notes*:
+                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.
+                 *
+                 *      *Notes*:
                  *      The category valueTypeID can search for values of a type ID. But it takes one or more two valued Tuple as list entry: (x,y). x is the type id and y is the searched value. This can be an int or a float, e.g: `{"operator":"lesserThan","values":[(3142,543.3)],"logicalOperator":"and"}`
                  *      The date categories (beginFrom, beginTo, endFrom, endTo) only allow *one* value in the **values** field and it has to be formated the following way: YYYY-MM-DD. Month and day values need to filled up with 0, e.g. 800-01-01
                  *
@@ -1713,7 +1876,29 @@ export interface operations {
                  *
                  *     **Logical operators**
                  *
-                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND. */
+                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND.
+                 *
+                 *      The following table outlines the supported operations for each field:
+                 *
+                 *     |                  | equal     | notEqual  | like      | greaterThan | greaterThanEqual | lesserThan | lesserThanEqual |
+                 *     |------------------|-----------|-----------|-----------|-------------|------------------|------------|-----------------|
+                 *     | entityName       |     x      |     x      |    x       |             |                  |            |                 |
+                 *     | entityDescription|      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entityAliases    |      x     |      x     |     x      |             |                  |            |                 |
+                 *     | entityCidocClass |      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entitySystemClass|      x     |      x     |     x      |             |                  |            |                 |
+                 *     | typeName         |       x    |      x     |     x      |             |                  |            |                 |
+                 *     | entityID         |       x    |      x     |           |             |                  |            |                 |
+                 *     | typeID           |      x     |       x    |           |             |                  |            |                 |
+                 *     | valueTypeID      |      x     |      x     |           |      x       |    x              |    x        |      x           |
+                 *     | typeIDWithSubs   |      x     |       x    |           |             |                  |            |                 |
+                 *     | relationToID     |      x     |      x     |           |             |                  |            |                 |
+                 *     | beginFrom        |      x     |      x     |           |      x       |        x          |     x       |      x           |
+                 *     | beginTo          |      x     |      x     |           |      x       |          x        |      x      |       x          |
+                 *     | endFrom          |      x     |      x     |           |       x      |         x         |       x     |       x          |
+                 *     | endTo            |      x     |      x     |           |       x      |       x           |       x     |      x           |
+                 *
+                 *      */
                 search?: components["parameters"]["search"];
                 /** @description Show only entities with the given type id or linked to it. */
                 type_id?: components["parameters"]["type_id"];
@@ -1734,18 +1919,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/ld+json": components["schemas"]["EntitiesOutputModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1763,18 +1944,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": components["schemas"]["LicensedFileOverviewModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1815,7 +1992,9 @@ export interface operations {
                  *
                  *      **Values**
                  *
-                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.\n *Notes*:
+                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.
+                 *
+                 *      *Notes*:
                  *      The category valueTypeID can search for values of a type ID. But it takes one or more two valued Tuple as list entry: (x,y). x is the type id and y is the searched value. This can be an int or a float, e.g: `{"operator":"lesserThan","values":[(3142,543.3)],"logicalOperator":"and"}`
                  *      The date categories (beginFrom, beginTo, endFrom, endTo) only allow *one* value in the **values** field and it has to be formated the following way: YYYY-MM-DD. Month and day values need to filled up with 0, e.g. 800-01-01
                  *
@@ -1831,7 +2010,29 @@ export interface operations {
                  *
                  *     **Logical operators**
                  *
-                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND. */
+                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND.
+                 *
+                 *      The following table outlines the supported operations for each field:
+                 *
+                 *     |                  | equal     | notEqual  | like      | greaterThan | greaterThanEqual | lesserThan | lesserThanEqual |
+                 *     |------------------|-----------|-----------|-----------|-------------|------------------|------------|-----------------|
+                 *     | entityName       |     x      |     x      |    x       |             |                  |            |                 |
+                 *     | entityDescription|      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entityAliases    |      x     |      x     |     x      |             |                  |            |                 |
+                 *     | entityCidocClass |      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entitySystemClass|      x     |      x     |     x      |             |                  |            |                 |
+                 *     | typeName         |       x    |      x     |     x      |             |                  |            |                 |
+                 *     | entityID         |       x    |      x     |           |             |                  |            |                 |
+                 *     | typeID           |      x     |       x    |           |             |                  |            |                 |
+                 *     | valueTypeID      |      x     |      x     |           |      x       |    x              |    x        |      x           |
+                 *     | typeIDWithSubs   |      x     |       x    |           |             |                  |            |                 |
+                 *     | relationToID     |      x     |      x     |           |             |                  |            |                 |
+                 *     | beginFrom        |      x     |      x     |           |      x       |        x          |     x       |      x           |
+                 *     | beginTo          |      x     |      x     |           |      x       |          x        |      x      |       x          |
+                 *     | endFrom          |      x     |      x     |           |       x      |         x         |       x     |       x          |
+                 *     | endTo            |      x     |      x     |           |       x      |       x           |       x     |      x           |
+                 *
+                 *      */
                 search?: components["parameters"]["search"];
                 /** @description Begin results at the given entity id. */
                 first?: components["parameters"]["first"];
@@ -1864,18 +2065,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/ld+json": components["schemas"]["EntitiesOutputModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1898,18 +2095,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": components["schemas"]["NetworkVisualisationModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1930,18 +2123,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": components["schemas"]["PropertiesModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -1998,7 +2187,9 @@ export interface operations {
                  *
                  *      **Values**
                  *
-                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.\n *Notes*:
+                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.
+                 *
+                 *      *Notes*:
                  *      The category valueTypeID can search for values of a type ID. But it takes one or more two valued Tuple as list entry: (x,y). x is the type id and y is the searched value. This can be an int or a float, e.g: `{"operator":"lesserThan","values":[(3142,543.3)],"logicalOperator":"and"}`
                  *      The date categories (beginFrom, beginTo, endFrom, endTo) only allow *one* value in the **values** field and it has to be formated the following way: YYYY-MM-DD. Month and day values need to filled up with 0, e.g. 800-01-01
                  *
@@ -2014,7 +2205,29 @@ export interface operations {
                  *
                  *     **Logical operators**
                  *
-                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND. */
+                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND.
+                 *
+                 *      The following table outlines the supported operations for each field:
+                 *
+                 *     |                  | equal     | notEqual  | like      | greaterThan | greaterThanEqual | lesserThan | lesserThanEqual |
+                 *     |------------------|-----------|-----------|-----------|-------------|------------------|------------|-----------------|
+                 *     | entityName       |     x      |     x      |    x       |             |                  |            |                 |
+                 *     | entityDescription|      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entityAliases    |      x     |      x     |     x      |             |                  |            |                 |
+                 *     | entityCidocClass |      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entitySystemClass|      x     |      x     |     x      |             |                  |            |                 |
+                 *     | typeName         |       x    |      x     |     x      |             |                  |            |                 |
+                 *     | entityID         |       x    |      x     |           |             |                  |            |                 |
+                 *     | typeID           |      x     |       x    |           |             |                  |            |                 |
+                 *     | valueTypeID      |      x     |      x     |           |      x       |    x              |    x        |      x           |
+                 *     | typeIDWithSubs   |      x     |       x    |           |             |                  |            |                 |
+                 *     | relationToID     |      x     |      x     |           |             |                  |            |                 |
+                 *     | beginFrom        |      x     |      x     |           |      x       |        x          |     x       |      x           |
+                 *     | beginTo          |      x     |      x     |           |      x       |          x        |      x      |       x          |
+                 *     | endFrom          |      x     |      x     |           |       x      |         x         |       x     |       x          |
+                 *     | endTo            |      x     |      x     |           |       x      |       x           |       x     |      x           |
+                 *
+                 *      */
                 search?: components["parameters"]["search"];
                 /** @description Begin results at the given entity id. */
                 first?: components["parameters"]["first"];
@@ -2039,18 +2252,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/ld+json": components["schemas"]["EntitiesOutputModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -2075,18 +2284,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": components["schemas"]["SubunitsModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -2125,7 +2330,9 @@ export interface operations {
                  *
                  *      **Values**
                  *
-                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.\n *Notes*:
+                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.
+                 *
+                 *      *Notes*:
                  *      The category valueTypeID can search for values of a type ID. But it takes one or more two valued Tuple as list entry: (x,y). x is the type id and y is the searched value. This can be an int or a float, e.g: `{"operator":"lesserThan","values":[(3142,543.3)],"logicalOperator":"and"}`
                  *      The date categories (beginFrom, beginTo, endFrom, endTo) only allow *one* value in the **values** field and it has to be formated the following way: YYYY-MM-DD. Month and day values need to filled up with 0, e.g. 800-01-01
                  *
@@ -2141,7 +2348,29 @@ export interface operations {
                  *
                  *     **Logical operators**
                  *
-                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND. */
+                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND.
+                 *
+                 *      The following table outlines the supported operations for each field:
+                 *
+                 *     |                  | equal     | notEqual  | like      | greaterThan | greaterThanEqual | lesserThan | lesserThanEqual |
+                 *     |------------------|-----------|-----------|-----------|-------------|------------------|------------|-----------------|
+                 *     | entityName       |     x      |     x      |    x       |             |                  |            |                 |
+                 *     | entityDescription|      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entityAliases    |      x     |      x     |     x      |             |                  |            |                 |
+                 *     | entityCidocClass |      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entitySystemClass|      x     |      x     |     x      |             |                  |            |                 |
+                 *     | typeName         |       x    |      x     |     x      |             |                  |            |                 |
+                 *     | entityID         |       x    |      x     |           |             |                  |            |                 |
+                 *     | typeID           |      x     |       x    |           |             |                  |            |                 |
+                 *     | valueTypeID      |      x     |      x     |           |      x       |    x              |    x        |      x           |
+                 *     | typeIDWithSubs   |      x     |       x    |           |             |                  |            |                 |
+                 *     | relationToID     |      x     |      x     |           |             |                  |            |                 |
+                 *     | beginFrom        |      x     |      x     |           |      x       |        x          |     x       |      x           |
+                 *     | beginTo          |      x     |      x     |           |      x       |          x        |      x      |       x          |
+                 *     | endFrom          |      x     |      x     |           |       x      |         x         |       x     |       x          |
+                 *     | endTo            |      x     |      x     |           |       x      |       x           |       x     |      x           |
+                 *
+                 *      */
                 search?: components["parameters"]["search"];
                 /** @description Begin results at the given entity id. */
                 first?: components["parameters"]["first"];
@@ -2174,18 +2403,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/ld+json": components["schemas"]["EntitiesOutputModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -2204,18 +2429,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": components["schemas"]["SystemClassCountModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -2234,18 +2455,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": components["schemas"]["TypesByViewClassModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -2284,7 +2501,9 @@ export interface operations {
                  *
                  *      **Values**
                  *
-                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.\n *Notes*:
+                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.
+                 *
+                 *      *Notes*:
                  *      The category valueTypeID can search for values of a type ID. But it takes one or more two valued Tuple as list entry: (x,y). x is the type id and y is the searched value. This can be an int or a float, e.g: `{"operator":"lesserThan","values":[(3142,543.3)],"logicalOperator":"and"}`
                  *      The date categories (beginFrom, beginTo, endFrom, endTo) only allow *one* value in the **values** field and it has to be formated the following way: YYYY-MM-DD. Month and day values need to filled up with 0, e.g. 800-01-01
                  *
@@ -2300,7 +2519,29 @@ export interface operations {
                  *
                  *     **Logical operators**
                  *
-                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND. */
+                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND.
+                 *
+                 *      The following table outlines the supported operations for each field:
+                 *
+                 *     |                  | equal     | notEqual  | like      | greaterThan | greaterThanEqual | lesserThan | lesserThanEqual |
+                 *     |------------------|-----------|-----------|-----------|-------------|------------------|------------|-----------------|
+                 *     | entityName       |     x      |     x      |    x       |             |                  |            |                 |
+                 *     | entityDescription|      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entityAliases    |      x     |      x     |     x      |             |                  |            |                 |
+                 *     | entityCidocClass |      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entitySystemClass|      x     |      x     |     x      |             |                  |            |                 |
+                 *     | typeName         |       x    |      x     |     x      |             |                  |            |                 |
+                 *     | entityID         |       x    |      x     |           |             |                  |            |                 |
+                 *     | typeID           |      x     |       x    |           |             |                  |            |                 |
+                 *     | valueTypeID      |      x     |      x     |           |      x       |    x              |    x        |      x           |
+                 *     | typeIDWithSubs   |      x     |       x    |           |             |                  |            |                 |
+                 *     | relationToID     |      x     |      x     |           |             |                  |            |                 |
+                 *     | beginFrom        |      x     |      x     |           |      x       |        x          |     x       |      x           |
+                 *     | beginTo          |      x     |      x     |           |      x       |          x        |      x      |       x          |
+                 *     | endFrom          |      x     |      x     |           |       x      |         x         |       x     |       x          |
+                 *     | endTo            |      x     |      x     |           |       x      |       x           |       x     |      x           |
+                 *
+                 *      */
                 search?: components["parameters"]["search"];
                 /** @description Begin results at the given entity id. */
                 first?: components["parameters"]["first"];
@@ -2333,18 +2574,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/ld+json": components["schemas"]["EntitiesOutputModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -2383,7 +2620,9 @@ export interface operations {
                  *
                  *      **Values**
                  *
-                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.\n *Notes*:
+                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.
+                 *
+                 *      *Notes*:
                  *      The category valueTypeID can search for values of a type ID. But it takes one or more two valued Tuple as list entry: (x,y). x is the type id and y is the searched value. This can be an int or a float, e.g: `{"operator":"lesserThan","values":[(3142,543.3)],"logicalOperator":"and"}`
                  *      The date categories (beginFrom, beginTo, endFrom, endTo) only allow *one* value in the **values** field and it has to be formated the following way: YYYY-MM-DD. Month and day values need to filled up with 0, e.g. 800-01-01
                  *
@@ -2399,7 +2638,29 @@ export interface operations {
                  *
                  *     **Logical operators**
                  *
-                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND. */
+                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND.
+                 *
+                 *      The following table outlines the supported operations for each field:
+                 *
+                 *     |                  | equal     | notEqual  | like      | greaterThan | greaterThanEqual | lesserThan | lesserThanEqual |
+                 *     |------------------|-----------|-----------|-----------|-------------|------------------|------------|-----------------|
+                 *     | entityName       |     x      |     x      |    x       |             |                  |            |                 |
+                 *     | entityDescription|      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entityAliases    |      x     |      x     |     x      |             |                  |            |                 |
+                 *     | entityCidocClass |      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entitySystemClass|      x     |      x     |     x      |             |                  |            |                 |
+                 *     | typeName         |       x    |      x     |     x      |             |                  |            |                 |
+                 *     | entityID         |       x    |      x     |           |             |                  |            |                 |
+                 *     | typeID           |      x     |       x    |           |             |                  |            |                 |
+                 *     | valueTypeID      |      x     |      x     |           |      x       |    x              |    x        |      x           |
+                 *     | typeIDWithSubs   |      x     |       x    |           |             |                  |            |                 |
+                 *     | relationToID     |      x     |      x     |           |             |                  |            |                 |
+                 *     | beginFrom        |      x     |      x     |           |      x       |        x          |     x       |      x           |
+                 *     | beginTo          |      x     |      x     |           |      x       |          x        |      x      |       x          |
+                 *     | endFrom          |      x     |      x     |           |       x      |         x         |       x     |       x          |
+                 *     | endTo            |      x     |      x     |           |       x      |       x           |       x     |      x           |
+                 *
+                 *      */
                 search?: components["parameters"]["search"];
                 /** @description Begin results at the given entity id. */
                 first?: components["parameters"]["first"];
@@ -2432,18 +2693,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/ld+json": components["schemas"]["EntitiesOutputModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -2462,18 +2719,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": components["schemas"]["TypeOverviewModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -2492,18 +2745,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/json": components["schemas"]["TypeTreeModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };
@@ -2542,7 +2791,9 @@ export interface operations {
                  *
                  *      **Values**
                  *
-                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.\n *Notes*:
+                 *      Values has to be a list of items. The items can be either a string, an integer or a tuple (see Notes). Strings need to be marked with “” or ‘’, while integers does not allow this.
+                 *
+                 *      *Notes*:
                  *      The category valueTypeID can search for values of a type ID. But it takes one or more two valued Tuple as list entry: (x,y). x is the type id and y is the searched value. This can be an int or a float, e.g: `{"operator":"lesserThan","values":[(3142,543.3)],"logicalOperator":"and"}`
                  *      The date categories (beginFrom, beginTo, endFrom, endTo) only allow *one* value in the **values** field and it has to be formated the following way: YYYY-MM-DD. Month and day values need to filled up with 0, e.g. 800-01-01
                  *
@@ -2558,7 +2809,29 @@ export interface operations {
                  *
                  *     **Logical operators**
                  *
-                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND. */
+                 *     Not mandatory, OR is the default value. Logical operators handles, if the values are treated as OR or AND.
+                 *
+                 *      The following table outlines the supported operations for each field:
+                 *
+                 *     |                  | equal     | notEqual  | like      | greaterThan | greaterThanEqual | lesserThan | lesserThanEqual |
+                 *     |------------------|-----------|-----------|-----------|-------------|------------------|------------|-----------------|
+                 *     | entityName       |     x      |     x      |    x       |             |                  |            |                 |
+                 *     | entityDescription|      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entityAliases    |      x     |      x     |     x      |             |                  |            |                 |
+                 *     | entityCidocClass |      x     |      x     |      x     |             |                  |            |                 |
+                 *     | entitySystemClass|      x     |      x     |     x      |             |                  |            |                 |
+                 *     | typeName         |       x    |      x     |     x      |             |                  |            |                 |
+                 *     | entityID         |       x    |      x     |           |             |                  |            |                 |
+                 *     | typeID           |      x     |       x    |           |             |                  |            |                 |
+                 *     | valueTypeID      |      x     |      x     |           |      x       |    x              |    x        |      x           |
+                 *     | typeIDWithSubs   |      x     |       x    |           |             |                  |            |                 |
+                 *     | relationToID     |      x     |      x     |           |             |                  |            |                 |
+                 *     | beginFrom        |      x     |      x     |           |      x       |        x          |     x       |      x           |
+                 *     | beginTo          |      x     |      x     |           |      x       |          x        |      x      |       x          |
+                 *     | endFrom          |      x     |      x     |           |       x      |         x         |       x     |       x          |
+                 *     | endTo            |      x     |      x     |           |       x      |       x           |       x     |      x           |
+                 *
+                 *      */
                 search?: components["parameters"]["search"];
                 /** @description Begin results at the given entity id. */
                 first?: components["parameters"]["first"];
@@ -2591,18 +2864,14 @@ export interface operations {
         responses: {
             /** @description Success */
             200: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content: {
                     "application/ld+json": components["schemas"]["EntitiesOutputModel"];
                 };
             };
             /** @description Something went wrong. Please consult the error message. */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
+                headers: Record<string, unknown>;
                 content?: never;
             };
         };

--- a/types/api.ts
+++ b/types/api.ts
@@ -6,7 +6,7 @@ type LinkedPlacesModelFeature = LinkedPlacesModel["features"][number];
 
 export interface LinkedPlaceFeature extends LinkedPlacesModelFeature {
 	type: "Feature";
-	geometry:
+	geometry?:
 		| components["schemas"]["GeometryCollection"]
 		| components["schemas"]["LineString"]
 		| components["schemas"]["Point"]

--- a/utils/create-geojson-feature.ts
+++ b/utils/create-geojson-feature.ts
@@ -1,3 +1,4 @@
+import { assert } from "@acdh-oeaw/lib";
 import type { Feature, Geometry } from "geojson";
 
 import type { EntityFeature } from "@/composables/use-create-entity";
@@ -5,6 +6,7 @@ import type { EntityFeature } from "@/composables/use-create-entity";
 export type GeoJsonFeature = Feature<Geometry, { _id: string }>;
 
 export function createGeoJsonFeature(entity: EntityFeature): GeoJsonFeature {
+	assert(entity.geometry !== undefined, "Entity geometry is required");
 	return {
 		type: "Feature",
 		geometry: entity.geometry,


### PR DESCRIPTION
In the latest release of OA 8.10.0, some `geometry` objects have vanished from the `/query/` result list, causing our map views to break. This PR is a quick fix, further investigation of the actual cause might be needed.