### PR TITLE
feat: make the detail view expandable and move mode switch inside the…

### DIFF
--- a/components/entity-primary-details.vue
+++ b/components/entity-primary-details.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { CheckIcon, CopyIcon } from "lucide-vue-next";
-
 import CustomPrimaryDetails from "@/components/custom-primary-details.vue";
 import CustomPrimaryDetailsActor from "@/components/custom-primary-details-actor.vue";
 import CustomPrimaryDetailsEvent from "@/components/custom-primary-details-event.vue";
@@ -14,7 +12,6 @@ const getRelationTitle = (relation: RelationType) => {
 };
 
 const { getUnprefixedId } = useIdPrefix();
-const route = useRoute();
 const requestURL = useRequestURL();
 const t = useTranslations();
 
@@ -112,8 +109,6 @@ interface Place {
 	relationType: RelationType | null;
 }
 
-const isCopied = ref(false);
-
 // TODO: For instances where there is no location set (at least for actors), make use of first and last event if no places are available
 const places = computed(() => {
 	console.log(props.entity);
@@ -137,10 +132,6 @@ const places = computed(() => {
 });
 
 watchEffect(() => {
-	if (route.query.selection) {
-		isCopied.value = false;
-	}
-
 	if (!places.value || places.value.length === 0) return;
 	const relTypes = places.value.map((place) => {
 		return place.relationType;
@@ -150,16 +141,6 @@ watchEffect(() => {
 	}
 	emitHandledRelations([]);
 });
-
-function copyEntity() {
-	const fullUrl = window.location.href;
-	const baseUrl = fullUrl.split(route.path)[0];
-	if (baseUrl) {
-		isCopied.value = true;
-		return navigator.clipboard.writeText(`${baseUrl}/entity/${route.query.selection as string}`);
-	}
-	return null;
-}
 
 const tabs = computed(() => {
 	const tabs = [];
@@ -251,21 +232,7 @@ watch(
 </script>
 
 <template>
-	<div class="grid grid-cols-1 md:grid-cols-[auto_auto]">
-		<EntitySystemClass :system-class="entity.systemClass" />
-		<div v-if="!isCopied" class="ml-auto">
-			<Button variant="outline" @click="copyEntity">
-				<CopyIcon :size="16" />
-				{{ t("EntitySidebar.copy") }}
-			</Button>
-		</div>
-		<div v-if="isCopied" class="ml-auto">
-			<Button variant="brand" @click="copyEntity">
-				<CheckIcon :size="16" />
-				{{ t("EntitySidebar.copied") }}
-			</Button>
-		</div>
-	</div>
+	<EntitySystemClass :system-class="entity.systemClass" />
 	<PageTitle>{{ entity.title }}</PageTitle>
 	<!-- @ts-expect FIXME: Incorrect information provided by openapi document. -->
 	<EntityAliases v-if="entity.aliases" :aliases="entity.aliases as unknown as Array<string>" />

--- a/components/entity-sidebar.vue
+++ b/components/entity-sidebar.vue
@@ -114,7 +114,7 @@ function copyEntity() {
 											}
 										"
 									>
-										<span classs="sr-only"> {{ t("EntitySidebar.copy") }}</span>
+										<span class="sr-only"> {{ t("EntitySidebar.copy") }}</span>
 										<CopyIcon :size="16" />
 									</Button>
 								</TooltipTrigger>

--- a/components/entity-sidebar.vue
+++ b/components/entity-sidebar.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { ChevronLeftIcon, ChevronRightIcon, XIcon } from "lucide-vue-next";
+import { ChevronLeftIcon, ChevronRightIcon, CopyIcon, XIcon } from "lucide-vue-next";
+
+import { toast } from "@/components/ui/toast";
 
 const t = useTranslations();
 const router = useRouter();
@@ -7,6 +9,7 @@ const route = useRoute();
 
 const props = defineProps<{
 	id: number;
+	mode: string;
 	noTableSidebar: boolean;
 }>();
 
@@ -21,6 +24,7 @@ const entity = computed(() => {
 });
 
 const openState = ref(false);
+const expandedState = ref(false);
 
 onMounted(() => {
 	openState.value = true;
@@ -35,6 +39,7 @@ watch(
 	},
 	{ immediate: true, deep: true },
 );
+
 const handledRelations = ref<Array<RelationType>>([]);
 
 const updateHandledRelations = (relations: Array<RelationType>) => {
@@ -42,8 +47,15 @@ const updateHandledRelations = (relations: Array<RelationType>) => {
 };
 
 function clearSelection() {
-	void router.push({ query: { ...route.query, selection: null } });
+	const query = { ...route.query };
+	delete query.selection;
+
+	void router.push({
+		path: route.path,
+		query,
+	});
 }
+
 defineExpose({ openState });
 
 const nonEmptyRelations = computed(() => {
@@ -53,28 +65,69 @@ const nonEmptyRelations = computed(() => {
 	});
 	return filteredEntries.length > 0 ? Object.fromEntries(filteredEntries) : null;
 });
+
+function copyEntity() {
+	const fullUrl = window.location.href;
+	const baseUrl = fullUrl.split(route.path)[0];
+	if (baseUrl) {
+		return navigator.clipboard.writeText(`${baseUrl}/entity/${route.query.selection as string}`);
+	}
+	return null;
+}
 </script>
 
 <template>
 	<div v-if="entity != null && props.id != null">
 		<div
-			class="group z-20 mb-2 mr-2 flex h-full transition-transform duration-300"
-			:class="{
-				'absolute w-1/4': props.noTableSidebar,
-				'translate-x-0': openState,
-				'-translate-x-full': !openState,
-			}"
-			:open="openState"
+			class="group z-20 mb-2 mr-2 flex h-full bg-white transition-all duration-300 ease-in-out"
+			:style="
+				noTableSidebar
+					? {
+							width: expandedState ? 'calc(100% - 2rem)' : '25%',
+							position: 'absolute',
+						}
+					: {}
+			"
 		>
 			<div
 				class="relative size-full max-h-full grow basis-full overflow-y-auto rounded-lg border bg-card px-6 py-4 text-card-foreground shadow"
 			>
-				<Button
-					variant="transparent"
-					class="float-right -mr-6 -mt-4 p-2 text-neutral-600 hover:text-black dark:text-neutral-400 dark:hover:text-white"
-					@click="clearSelection"
-					><XIcon class="size-4"></XIcon
-				></Button>
+				<div class="float-right flex flex-row items-center gap-2">
+					<div class="flex flex-row items-center">
+						<ModeSwitch :id="id" :current-mode="mode" />
+						<span class="text-neutral-300">|</span>
+					</div>
+
+					<div class="ml-auto">
+						<TooltipProvider>
+							<Tooltip>
+								<TooltipTrigger>
+									<Button
+										variant="ghost"
+										class="h-full p-2"
+										@click="
+											() => {
+												toast.success(t('EntitySidebar.copied'), {
+													description: t('EntitySidebar.copiedMessage'),
+												});
+												copyEntity();
+											}
+										"
+									>
+										<span classs="sr-only"> {{ t("EntitySidebar.copy") }}</span>
+										<CopyIcon :size="16" />
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent>
+									<span>{{ t("EntitySidebar.copy") }}</span>
+								</TooltipContent>
+							</Tooltip>
+						</TooltipProvider>
+					</div>
+					<Button variant="ghost" class="h-full p-2" @click="clearSelection"
+						><XIcon class="size-4"></XIcon
+					></Button>
+				</div>
 				<EntityPrimaryDetails :entity="entity" @handled-relations="updateHandledRelations" />
 
 				<slot name="custom-details" />
@@ -90,12 +143,15 @@ const nonEmptyRelations = computed(() => {
 			<button
 				class="absolute left-full top-1/2 -z-10 block -translate-x-2 rounded-md bg-[hsl(var(--card))] py-2 pl-1 shadow-md"
 				style="top: calc(50% - 40px)"
-				@click="openState = !openState"
+				@click="expandedState = !expandedState"
 			>
-				<ChevronLeftIcon class="ml-auto size-8" :class="{ block: openState, hidden: !openState }" />
+				<ChevronLeftIcon
+					class="ml-auto size-8"
+					:class="{ block: expandedState, hidden: !expandedState }"
+				/>
 				<ChevronRightIcon
 					class="ml-auto size-8"
-					:class="{ hidden: openState, block: !openState }"
+					:class="{ hidden: expandedState, block: !expandedState }"
 				/>
 				<span class="sr-only">{{ t("EntityPage.sidebar.toggle", { title: entity.title }) }}</span>
 			</button>

--- a/components/mode-switch.vue
+++ b/components/mode-switch.vue
@@ -75,17 +75,17 @@ function entityInNetwork(entity: PresentationViewModel) {
 </script>
 
 <template>
-	<div class="grid gap-2 rounded-md bg-white/90 p-4 shadow-md dark:bg-black/90">
+	<div id="modeSwitch" class="flex w-fit flex-row gap-1.5 rounded-md p-2">
 		<TooltipProvider>
 			<Tooltip>
-				<TooltipTrigger>
+				<TooltipTrigger :style="{ cursor: inNetwork ? 'pointer' : 'auto' }">
 					<div
 						:class="
 							props.currentMode === 'map'
-								? 'rounded-md bg-brand p-4 shadow-md'
+								? 'bg-brand/90 text-white hover:bg-brand/90 p-1.5 rounded-md'
 								: !hasPlace
-									? 'rounded-md bg-neutral-300 p-4 shadow-md'
-									: 'rounded-md bg-primary/90 p-4 shadow-md dark:bg-white'
+									? 'rounded-md text-neutral-300 p-2'
+									: 'hover:bg-accent hover:text-accent-foreground rounded-md p-2 text-black dark:text-white'
 						"
 					>
 						<NavLink
@@ -99,9 +99,9 @@ function entityInNetwork(entity: PresentationViewModel) {
 								},
 							}"
 						>
-							<MapPinIcon class="size-6 text-white dark:text-black" />
+							<MapPinIcon :size="16" />
 						</NavLink>
-						<MapPinOffIcon v-if="!hasPlace" class="size-6 text-white dark:text-black" />
+						<MapPinOffIcon v-if="!hasPlace" :size="16" />
 					</div>
 				</TooltipTrigger>
 				<TooltipContent>
@@ -112,14 +112,14 @@ function entityInNetwork(entity: PresentationViewModel) {
 		</TooltipProvider>
 		<TooltipProvider>
 			<Tooltip>
-				<TooltipTrigger>
+				<TooltipTrigger :style="{ cursor: inNetwork ? 'pointer' : 'auto' }">
 					<div
 						:class="
 							props.currentMode === 'network'
-								? 'rounded-md bg-brand p-4 shadow-md'
+								? 'bg-brand/90 text-white hover:bg-brand/90 p-1.5 rounded-md'
 								: !inNetwork
-									? 'rounded-md bg-neutral-300 p-4 shadow-md'
-									: 'rounded-md bg-primary/90 p-4 shadow-md dark:bg-white'
+									? 'rounded-md text-neutral-300 p-2'
+									: 'hover:bg-accent hover:text-accent-foreground rounded-md p-2 text-black dark:text-white'
 						"
 					>
 						<NavLink
@@ -133,9 +133,9 @@ function entityInNetwork(entity: PresentationViewModel) {
 								},
 							}"
 						>
-							<RadiusIcon class="size-6 text-white dark:text-black" />
+							<RadiusIcon :size="16" />
 						</NavLink>
-						<CircleOffIcon v-if="!inNetwork" class="size-6 text-white dark:text-black" />
+						<CircleOffIcon v-if="!inNetwork" :size="16" />
 					</div>
 				</TooltipTrigger>
 				<TooltipContent>
@@ -150,8 +150,8 @@ function entityInNetwork(entity: PresentationViewModel) {
 					<div
 						:class="
 							props.currentMode === 'table'
-								? 'rounded-md bg-brand p-4 shadow-md'
-								: 'rounded-md bg-primary/90 p-4 shadow-md dark:bg-white'
+								? 'bg-brand/90 text-white hover:bg-brand/90 p-1.5 rounded-md'
+								: 'hover:bg-accent hover:text-accent-foreground rounded-md p-2 text-black dark:text-white'
 						"
 					>
 						<NavLink
@@ -164,7 +164,7 @@ function entityInNetwork(entity: PresentationViewModel) {
 								},
 							}"
 						>
-							<TablePropertiesIcon class="size-6 text-white dark:text-black" />
+							<TablePropertiesIcon :size="16" />
 						</NavLink>
 					</div>
 				</TooltipTrigger>

--- a/layouts/visualization.vue
+++ b/layouts/visualization.vue
@@ -1,9 +1,7 @@
 <script lang="ts" setup>
-import { MapPinIcon, RadiusIcon, TablePropertiesIcon } from "lucide-vue-next";
 import { useTemplateRef } from "vue";
 
 import EntitySidebar from "@/components/entity-sidebar.vue";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 const t = useTranslations();
 
@@ -23,13 +21,6 @@ const currentMode = computed(() => {
 	return route.query.mode as string;
 });
 
-function getPath() {
-	if (route.path.includes("visualization")) {
-		return "visualization";
-	}
-	return "";
-}
-
 const sidebar = useTemplateRef<typeof EntitySidebar>("sidebar");
 const sidebarOpen = computed(() => {
 	return sidebar.value?.openState;
@@ -38,100 +29,9 @@ const sidebarOpen = computed(() => {
 
 <template>
 	<NuxtLayout name="default">
-		<div class="absolute right-4 z-20" style="top: calc(50% - 110px)">
-			<ModeSwitch v-if="id != null" :id="id" :current-mode="currentMode" />
-			<div v-else>
-				<div class="grid gap-2 rounded-md bg-white/90 p-4 shadow-md dark:bg-black/90">
-					<TooltipProvider>
-						<Tooltip>
-							<TooltipTrigger>
-								<div
-									:class="
-										currentMode === 'map'
-											? 'rounded-md bg-brand p-4 shadow-md'
-											: 'rounded-md bg-primary/90 p-4 shadow-md dark:bg-white'
-									"
-								>
-									<NavLink
-										class="flex items-center gap-1 underline decoration-dotted hover:no-underline"
-										:href="{
-											path: `/${getPath()}`,
-											query: {
-												mode: 'map',
-											},
-										}"
-									>
-										<MapPinIcon class="size-6 text-white dark:text-black" />
-									</NavLink>
-								</div>
-							</TooltipTrigger>
-							<TooltipContent>
-								<p>{{ t("EntityPage.map") }}</p>
-							</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
-					<TooltipProvider>
-						<Tooltip>
-							<TooltipTrigger>
-								<div
-									:class="
-										currentMode === 'network'
-											? 'rounded-md bg-brand p-4 shadow-md'
-											: 'rounded-md bg-primary/90 p-4 shadow-md dark:bg-white'
-									"
-								>
-									<NavLink
-										class="flex items-center gap-1 underline decoration-dotted hover:no-underline"
-										:href="{
-											path: `/${getPath()}`,
-											query: {
-												mode: 'network',
-											},
-										}"
-									>
-										<RadiusIcon class="size-6 text-white dark:text-black" />
-									</NavLink>
-								</div>
-							</TooltipTrigger>
-							<TooltipContent>
-								<p>{{ t("EntityPage.network") }}</p>
-							</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
-					<TooltipProvider>
-						<Tooltip>
-							<TooltipTrigger>
-								<div
-									:class="
-										currentMode === 'table'
-											? 'rounded-md bg-brand p-4 shadow-md'
-											: 'rounded-md bg-primary/90 p-4 shadow-md dark:bg-white'
-									"
-								>
-									<NavLink
-										class="flex items-center gap-1 underline decoration-dotted hover:no-underline"
-										:href="{
-											path: `/${getPath()}`,
-											query: {
-												mode: 'table',
-											},
-										}"
-									>
-										<TablePropertiesIcon class="size-6 text-white dark:text-black" />
-									</NavLink>
-								</div>
-							</TooltipTrigger>
-							<TooltipContent>
-								<p>{{ t("DataPage.title") }}</p>
-							</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
-				</div>
-			</div>
-		</div>
 		<MainContent class="relative h-full">
 			<template v-if="id != null && currentMode !== 'table'">
-				<EntitySidebar :id="id" :no-table-sidebar="true" />
+				<EntitySidebar :id="id" :no-table-sidebar="true" :mode="currentMode" />
 			</template>
 			<div
 				class="relative grid h-full grid-cols-[0px_1fr] transition-all delay-150 ease-in-out data-[sidepanel]:grid-cols-[25vw_1fr]"
@@ -142,6 +42,7 @@ const sidebarOpen = computed(() => {
 						v-if="id != null && currentMode === 'table'"
 						:id="id"
 						ref="sidebar"
+						:mode="currentMode"
 						:no-table-sidebar="false"
 					/>
 				</div>

--- a/messages/de/common.json
+++ b/messages/de/common.json
@@ -98,7 +98,8 @@
 		"NextFeature": "Nächste Funktion",
 		"PreviousFeature": "Vorheriges Feature",
 		"copy": "Permalink",
-		"copied": "Kopiert!"
+		"copied": "Kopiert!",
+		"copiedMessage": "Der Permalink wurde erfolgreich auf das Clipboard kopiert."
 	},
 	"ErrorBoundary": {
 		"error": "Fehler"

--- a/messages/en/common.json
+++ b/messages/en/common.json
@@ -97,7 +97,8 @@
 		"NextFeature": "NextFeature",
 		"PreviousFeature": "Previous Feature",
 		"copy": "Permalink",
-		"copied": "Copied!"
+		"copied": "Copied!",
+		"copiedMessage": "The permalink has been successfully copied to the clipboard."
 	},
 	"ErrorBoundary": {
 		"error": "Error"


### PR DESCRIPTION
make the detail view expandable:
- this is instead of the minimize logic; now you can close the detail view.
- this is currently working in the map & network mode, the table mode stays fixed. 
- the design of the expanded detail view should be overworked. 

& move the mode switch inside the detail view and create kind of a toolbar. 